### PR TITLE
Replace DistributedDataParallel with DataParallel for teacher model with no updatable params

### DIFF
--- a/configs/official/coco2017/yoshitomo-matsubara/rrpr2020/ghnd-custom_fasterrcnn_resnet50_fpn_from_fasterrcnn_resnet50_fpn.yaml
+++ b/configs/official/coco2017/yoshitomo-matsubara/rrpr2020/ghnd-custom_fasterrcnn_resnet50_fpn_from_fasterrcnn_resnet50_fpn.yaml
@@ -79,7 +79,7 @@ train:
     forward_hook:
       input: []
       output: ['seq.backbone.body.layer1', 'seq.backbone.body.layer2', 'seq.backbone.body.layer3', 'seq.backbone.body.layer4']
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
   student:
     forward_proc: 'forward_batch'

--- a/configs/official/coco2017/yoshitomo-matsubara/rrpr2020/ghnd-custom_maskrcnn_resnet50_fpn_from_maskrcnn_resnet50_fpn.yaml
+++ b/configs/official/coco2017/yoshitomo-matsubara/rrpr2020/ghnd-custom_maskrcnn_resnet50_fpn_from_maskrcnn_resnet50_fpn.yaml
@@ -79,7 +79,7 @@ train:
     forward_hook:
       input: []
       output: ['seq.backbone.body.layer1', 'seq.backbone.body.layer2', 'seq.backbone.body.layer3', 'seq.backbone.body.layer4']
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
   student:
     forward_proc: 'forward_batch'

--- a/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/at-resnet18_from_resnet34.yaml
+++ b/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/at-resnet18_from_resnet34.yaml
@@ -72,7 +72,7 @@ train:
     forward_hook:
       input: []
       output: ['layer3', 'layer4']
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
   student:
     adaptations:

--- a/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/cse_l2-resnet18_from_resnet34.yaml
+++ b/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/cse_l2-resnet18_from_resnet34.yaml
@@ -72,7 +72,7 @@ train:
     forward_hook:
       input: []
       output: ['avgpool']
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
   student:
     adaptations:

--- a/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/kd-resnet18_from_resnet34.yaml
+++ b/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/kd-resnet18_from_resnet34.yaml
@@ -69,7 +69,7 @@ train:
     num_workers: 16
   teacher:
     sequential: []
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
   student:
     adaptations:

--- a/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/pad_l2-resnet18_from_resnet34.yaml
+++ b/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/pad_l2-resnet18_from_resnet34.yaml
@@ -73,7 +73,7 @@ train:
       forward_hook:
         input: []
         output: ['avgpool']
-      wrapper: 'DistributedDataParallel'
+      wrapper: 'DataParallel'
       requires_grad: False
     student:
       adaptations:

--- a/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/tfkd-resnet18_from_resnet18.yaml
+++ b/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/tfkd-resnet18_from_resnet18.yaml
@@ -69,7 +69,7 @@ train:
     num_workers: 16
   teacher:
     sequential: []
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
   student:
     adaptations:

--- a/configs/sample/cifar10/kd/resnet20_from_densenet_bc_k12_depth100-final_run.yaml
+++ b/configs/sample/cifar10/kd/resnet20_from_densenet_bc_k12_depth100-final_run.yaml
@@ -76,7 +76,7 @@ train:
     num_workers: 16
   teacher:
     sequential: []
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
     frozen_modules: []
   student:

--- a/configs/sample/cifar10/kd/resnet20_from_densenet_bc_k12_depth100-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/kd/resnet20_from_densenet_bc_k12_depth100-hyperparameter_tuning.yaml
@@ -76,7 +76,7 @@ train:
     num_workers: 16
   teacher:
     sequential: []
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
     frozen_modules: []
   student:

--- a/configs/sample/cifar10/kd/wide_resnet40_1_from_wide_resnet40_4-final_run.yaml
+++ b/configs/sample/cifar10/kd/wide_resnet40_1_from_wide_resnet40_4-final_run.yaml
@@ -79,7 +79,7 @@ train:
     num_workers: 16
   teacher:
     sequential: []
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
     frozen_modules: []
   student:

--- a/configs/sample/cifar10/kd/wide_resnet40_1_from_wide_resnet40_4-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/kd/wide_resnet40_1_from_wide_resnet40_4-hyperparameter_tuning.yaml
@@ -79,7 +79,7 @@ train:
     num_workers: 16
   teacher:
     sequential: []
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
     frozen_modules: []
   student:

--- a/configs/sample/cifar100/kd/densenet_bc_k12_depth100_from_wide_resnet28_10-final_run.yaml
+++ b/configs/sample/cifar100/kd/densenet_bc_k12_depth100_from_wide_resnet28_10-final_run.yaml
@@ -77,7 +77,7 @@ train:
     num_workers: 16
   teacher:
     sequential: []
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
     frozen_modules: []
   student:

--- a/configs/sample/cifar100/kd/densenet_bc_k12_depth100_from_wide_resnet28_10-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar100/kd/densenet_bc_k12_depth100_from_wide_resnet28_10-hyperparameter_tuning.yaml
@@ -77,7 +77,7 @@ train:
     num_workers: 16
   teacher:
     sequential: []
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
     frozen_modules: []
   student:

--- a/configs/sample/cifar100/kd/wide_resnet40_1_from_wide_resnet40_4-final_run.yaml
+++ b/configs/sample/cifar100/kd/wide_resnet40_1_from_wide_resnet40_4-final_run.yaml
@@ -79,7 +79,7 @@ train:
     num_workers: 16
   teacher:
     sequential: []
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
     frozen_modules: []
   student:

--- a/configs/sample/cifar100/kd/wide_resnet40_1_from_wide_resnet40_4-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar100/kd/wide_resnet40_1_from_wide_resnet40_4-hyperparameter_tuning.yaml
@@ -79,7 +79,7 @@ train:
     num_workers: 16
   teacher:
     sequential: []
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
     frozen_modules: []
   student:

--- a/configs/sample/coco2017/single_stage/ghnd/custom_fasterrcnn_resnet50_fpn_from_fasterrcnn_resnet50_fpn.yaml
+++ b/configs/sample/coco2017/single_stage/ghnd/custom_fasterrcnn_resnet50_fpn_from_fasterrcnn_resnet50_fpn.yaml
@@ -79,7 +79,7 @@ train:
     forward_hook:
       input: []
       output: ['seq.backbone.body.layer1', 'seq.backbone.body.layer2', 'seq.backbone.body.layer3', 'seq.backbone.body.layer4']
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
   student:
     forward_proc: 'forward_batch'

--- a/configs/sample/coco2017/single_stage/ghnd/custom_maskrcnn_resnet50_fpn_from_maskrcnn_resnet50_fpn.yaml
+++ b/configs/sample/coco2017/single_stage/ghnd/custom_maskrcnn_resnet50_fpn_from_maskrcnn_resnet50_fpn.yaml
@@ -79,7 +79,7 @@ train:
     forward_hook:
       input: []
       output: ['seq.backbone.body.layer1', 'seq.backbone.body.layer2', 'seq.backbone.body.layer3', 'seq.backbone.body.layer4']
-    wrapper: 'DistributedDataParallel'
+    wrapper: 'DataParallel'
     requires_grad: False
   student:
     forward_proc: 'forward_batch'


### PR DESCRIPTION
This PR resolves the issue #122 
Recent version of PyTorch doesn't allow wrapping models with no updatable params with `DistributedDataParallel` 
