### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ python:
   - "3.9"
 
 install:
+  - pip install setuptools --upgrade
   - pip install .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 os:
   - linux
 
-dist: bionic
+dist: focal
 
 cache:
   pip: true

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     packages=find_packages(exclude=('tests', 'examples', 'demo', 'configs')),
     python_requires='>=3.7',
     install_requires=[
+        'setuptools>=63.1.0'
         'torch>=1.11.0',
         'torchvision>=0.12.0',
         'numpy',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     packages=find_packages(exclude=('tests', 'examples', 'demo', 'configs')),
     python_requires='>=3.7',
     install_requires=[
-        'setuptools>=63.1.0'
         'torch>=1.11.0',
         'torchvision>=0.12.0',
         'numpy',


### PR DESCRIPTION
This PR resolves an issue "AttributeError: type object 'Distribution' has no attribute '_finalize_feature_opts" when building a package with Python 3.7 and 3.8 on Travis