### PR TITLE
Remove apex

### DIFF
--- a/configs/official/coco2017/yoshitomo-matsubara/rrpr2020/ghnd-custom_fasterrcnn_resnet50_fpn_from_fasterrcnn_resnet50_fpn.yaml
+++ b/configs/official/coco2017/yoshitomo-matsubara/rrpr2020/ghnd-custom_fasterrcnn_resnet50_fpn_from_fasterrcnn_resnet50_fpn.yaml
@@ -96,9 +96,6 @@ train:
       output: ['seq.backbone.body.layer1', 'seq.backbone.body.layer2', 'seq.backbone.body.layer3', 'seq.backbone.body.layer4']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/official/coco2017/yoshitomo-matsubara/rrpr2020/ghnd-custom_maskrcnn_resnet50_fpn_from_maskrcnn_resnet50_fpn.yaml
+++ b/configs/official/coco2017/yoshitomo-matsubara/rrpr2020/ghnd-custom_maskrcnn_resnet50_fpn_from_maskrcnn_resnet50_fpn.yaml
@@ -96,9 +96,6 @@ train:
       output: ['seq.backbone.body.layer1', 'seq.backbone.body.layer2', 'seq.backbone.body.layer3', 'seq.backbone.body.layer4']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/at-resnet18_from_resnet34.yaml
+++ b/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/at-resnet18_from_resnet34.yaml
@@ -83,9 +83,6 @@ train:
       output: ['layer3', 'layer4']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/crd-resnet18_from_resnet34.yaml
+++ b/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/crd-resnet18_from_resnet34.yaml
@@ -109,9 +109,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/cse_l2-resnet18_from_resnet34.yaml
+++ b/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/cse_l2-resnet18_from_resnet34.yaml
@@ -83,9 +83,6 @@ train:
       output: ['avgpool']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/kd-resnet18_from_resnet34.yaml
+++ b/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/kd-resnet18_from_resnet34.yaml
@@ -77,9 +77,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/tfkd-resnet18_from_resnet18.yaml
+++ b/configs/official/ilsvrc2012/yoshitomo-matsubara/rrpr2020/tfkd-resnet18_from_resnet18.yaml
@@ -77,9 +77,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/densenet_bc_k12_depth100-final_run.yaml
+++ b/configs/sample/cifar10/ce/densenet_bc_k12_depth100-final_run.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/densenet_bc_k12_depth100-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/ce/densenet_bc_k12_depth100-hyperparameter_tuning.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/densenet_bc_k24_depth250-final_run.yaml
+++ b/configs/sample/cifar10/ce/densenet_bc_k24_depth250-final_run.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/densenet_bc_k24_depth250-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/ce/densenet_bc_k24_depth250-hyperparameter_tuning.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/densenet_bc_k40_depth190-final_run.yaml
+++ b/configs/sample/cifar10/ce/densenet_bc_k40_depth190-final_run.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/densenet_bc_k40_depth190-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/ce/densenet_bc_k40_depth190-hyperparameter_tuning.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/resnet110-final_run.yaml
+++ b/configs/sample/cifar10/ce/resnet110-final_run.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/resnet110-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/ce/resnet110-hyperparameter_tuning.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/resnet1202-final_run.yaml
+++ b/configs/sample/cifar10/ce/resnet1202-final_run.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/resnet1202-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/ce/resnet1202-hyperparameter_tuning.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/resnet20-final_run.yaml
+++ b/configs/sample/cifar10/ce/resnet20-final_run.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/resnet20-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/ce/resnet20-hyperparameter_tuning.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/resnet32-final_run.yaml
+++ b/configs/sample/cifar10/ce/resnet32-final_run.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/resnet32-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/ce/resnet32-hyperparameter_tuning.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/resnet44-final_run.yaml
+++ b/configs/sample/cifar10/ce/resnet44-final_run.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/resnet44-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/ce/resnet44-hyperparameter_tuning.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/resnet56-final_run.yaml
+++ b/configs/sample/cifar10/ce/resnet56-final_run.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/resnet56-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/ce/resnet56-hyperparameter_tuning.yaml
@@ -72,9 +72,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/wide_resnet16_8-final_run.yaml
+++ b/configs/sample/cifar10/ce/wide_resnet16_8-final_run.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/wide_resnet16_8-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/ce/wide_resnet16_8-hyperparameter_tuning.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/wide_resnet28_10-final_run.yaml
+++ b/configs/sample/cifar10/ce/wide_resnet28_10-final_run.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/wide_resnet28_10-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/ce/wide_resnet28_10-hyperparameter_tuning.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/wide_resnet40_4-final_run.yaml
+++ b/configs/sample/cifar10/ce/wide_resnet40_4-final_run.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/ce/wide_resnet40_4-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/ce/wide_resnet40_4-hyperparameter_tuning.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/kd/resnet20_from_densenet_bc_k12_depth100-final_run.yaml
+++ b/configs/sample/cifar10/kd/resnet20_from_densenet_bc_k12_depth100-final_run.yaml
@@ -85,9 +85,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/kd/resnet20_from_densenet_bc_k12_depth100-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/kd/resnet20_from_densenet_bc_k12_depth100-hyperparameter_tuning.yaml
@@ -85,9 +85,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/kd/wide_resnet40_1_from_wide_resnet40_4-final_run.yaml
+++ b/configs/sample/cifar10/kd/wide_resnet40_1_from_wide_resnet40_4-final_run.yaml
@@ -89,9 +89,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar10/kd/wide_resnet40_1_from_wide_resnet40_4-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar10/kd/wide_resnet40_1_from_wide_resnet40_4-hyperparameter_tuning.yaml
@@ -89,9 +89,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/ce/densenet_bc_k12_depth100-final_run.yaml
+++ b/configs/sample/cifar100/ce/densenet_bc_k12_depth100-final_run.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/ce/densenet_bc_k12_depth100-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar100/ce/densenet_bc_k12_depth100-hyperparameter_tuning.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/ce/densenet_bc_k24_depth250-final_run.yaml
+++ b/configs/sample/cifar100/ce/densenet_bc_k24_depth250-final_run.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/ce/densenet_bc_k24_depth250-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar100/ce/densenet_bc_k24_depth250-hyperparameter_tuning.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/ce/densenet_bc_k40_depth190-final_run.yaml
+++ b/configs/sample/cifar100/ce/densenet_bc_k40_depth190-final_run.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/ce/densenet_bc_k40_depth190-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar100/ce/densenet_bc_k40_depth190-hyperparameter_tuning.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/ce/wide_resnet16_8-final_run.yaml
+++ b/configs/sample/cifar100/ce/wide_resnet16_8-final_run.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/ce/wide_resnet16_8-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar100/ce/wide_resnet16_8-hyperparameter_tuning.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/ce/wide_resnet28_10-final_run.yaml
+++ b/configs/sample/cifar100/ce/wide_resnet28_10-final_run.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/ce/wide_resnet28_10-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar100/ce/wide_resnet28_10-hyperparameter_tuning.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/ce/wide_resnet40_4-final_run.yaml
+++ b/configs/sample/cifar100/ce/wide_resnet40_4-final_run.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/ce/wide_resnet40_4-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar100/ce/wide_resnet40_4-hyperparameter_tuning.yaml
@@ -73,9 +73,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/kd/densenet_bc_k12_depth100_from_wide_resnet28_10-final_run.yaml
+++ b/configs/sample/cifar100/kd/densenet_bc_k12_depth100_from_wide_resnet28_10-final_run.yaml
@@ -86,9 +86,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/kd/densenet_bc_k12_depth100_from_wide_resnet28_10-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar100/kd/densenet_bc_k12_depth100_from_wide_resnet28_10-hyperparameter_tuning.yaml
@@ -86,9 +86,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/kd/wide_resnet40_1_from_wide_resnet40_4-final_run.yaml
+++ b/configs/sample/cifar100/kd/wide_resnet40_1_from_wide_resnet40_4-final_run.yaml
@@ -89,9 +89,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/cifar100/kd/wide_resnet40_1_from_wide_resnet40_4-hyperparameter_tuning.yaml
+++ b/configs/sample/cifar100/kd/wide_resnet40_1_from_wide_resnet40_4-hyperparameter_tuning.yaml
@@ -89,9 +89,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/coco2017/single_stage/ce/deeplabv3_resnet50.yaml
+++ b/configs/sample/coco2017/single_stage/ce/deeplabv3_resnet50.yaml
@@ -80,9 +80,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/coco2017/single_stage/ghnd/custom_fasterrcnn_resnet50_fpn_from_fasterrcnn_resnet50_fpn.yaml
+++ b/configs/sample/coco2017/single_stage/ghnd/custom_fasterrcnn_resnet50_fpn_from_fasterrcnn_resnet50_fpn.yaml
@@ -96,9 +96,6 @@ train:
       output: ['seq.backbone.body.layer1', 'seq.backbone.body.layer2', 'seq.backbone.body.layer3', 'seq.backbone.body.layer4']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/sample/coco2017/single_stage/ghnd/custom_maskrcnn_resnet50_fpn_from_maskrcnn_resnet50_fpn.yaml
+++ b/configs/sample/coco2017/single_stage/ghnd/custom_maskrcnn_resnet50_fpn_from_maskrcnn_resnet50_fpn.yaml
@@ -96,9 +96,6 @@ train:
       output: ['seq.backbone.body.layer1', 'seq.backbone.body.layer2', 'seq.backbone.body.layer3', 'seq.backbone.body.layer4']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/sample/glue/cola/ce/bert_base_uncased.yaml
+++ b/configs/sample/glue/cola/ce/bert_base_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/cola/ce/bert_large_uncased.yaml
+++ b/configs/sample/glue/cola/ce/bert_large_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/cola/kd/bert_base_uncased_from_bert_large_uncased.yaml
+++ b/configs/sample/glue/cola/kd/bert_base_uncased_from_bert_large_uncased.yaml
@@ -69,9 +69,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/mnli/ce/bert_base_uncased.yaml
+++ b/configs/sample/glue/mnli/ce/bert_base_uncased.yaml
@@ -60,9 +60,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/mnli/ce/bert_large_uncased.yaml
+++ b/configs/sample/glue/mnli/ce/bert_large_uncased.yaml
@@ -60,9 +60,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/mnli/kd/bert_base_uncased_from_bert_large_uncased.yaml
+++ b/configs/sample/glue/mnli/kd/bert_base_uncased_from_bert_large_uncased.yaml
@@ -79,9 +79,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/mrpc/ce/bert_base_uncased.yaml
+++ b/configs/sample/glue/mrpc/ce/bert_base_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/mrpc/ce/bert_large_uncased.yaml
+++ b/configs/sample/glue/mrpc/ce/bert_large_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/mrpc/kd/bert_base_uncased_from_bert_large_uncased.yaml
+++ b/configs/sample/glue/mrpc/kd/bert_base_uncased_from_bert_large_uncased.yaml
@@ -69,9 +69,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/qnli/ce/bert_base_uncased.yaml
+++ b/configs/sample/glue/qnli/ce/bert_base_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/qnli/ce/bert_large_uncased.yaml
+++ b/configs/sample/glue/qnli/ce/bert_large_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/qnli/kd/bert_base_uncased_from_bert_large_uncased.yaml
+++ b/configs/sample/glue/qnli/kd/bert_base_uncased_from_bert_large_uncased.yaml
@@ -69,9 +69,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/qqp/ce/bert_base_uncased.yaml
+++ b/configs/sample/glue/qqp/ce/bert_base_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/qqp/ce/bert_large_uncased.yaml
+++ b/configs/sample/glue/qqp/ce/bert_large_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/qqp/kd/bert_base_uncased_from_bert_large_uncased.yaml
+++ b/configs/sample/glue/qqp/kd/bert_base_uncased_from_bert_large_uncased.yaml
@@ -69,9 +69,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/rte/ce/bert_base_uncased.yaml
+++ b/configs/sample/glue/rte/ce/bert_base_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/rte/ce/bert_large_uncased.yaml
+++ b/configs/sample/glue/rte/ce/bert_large_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/rte/kd/bert_base_uncased_from_bert_large_uncased.yaml
+++ b/configs/sample/glue/rte/kd/bert_base_uncased_from_bert_large_uncased.yaml
@@ -69,9 +69,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/sst2/ce/bert_base_uncased.yaml
+++ b/configs/sample/glue/sst2/ce/bert_base_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/sst2/ce/bert_large_uncased.yaml
+++ b/configs/sample/glue/sst2/ce/bert_large_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/sst2/kd/bert_base_uncased_from_bert_large_uncased.yaml
+++ b/configs/sample/glue/sst2/kd/bert_base_uncased_from_bert_large_uncased.yaml
@@ -69,9 +69,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/stsb/kd/bert_base_uncased_from_bert_large_uncased.yaml
+++ b/configs/sample/glue/stsb/kd/bert_base_uncased_from_bert_large_uncased.yaml
@@ -75,9 +75,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/stsb/mse/bert_base_uncased.yaml
+++ b/configs/sample/glue/stsb/mse/bert_base_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/stsb/mse/bert_large_uncased.yaml
+++ b/configs/sample/glue/stsb/mse/bert_large_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/wnli/ce/bert_base_uncased.yaml
+++ b/configs/sample/glue/wnli/ce/bert_base_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/wnli/ce/bert_large_uncased.yaml
+++ b/configs/sample/glue/wnli/ce/bert_large_uncased.yaml
@@ -50,9 +50,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/glue/wnli/kd/bert_base_uncased_from_bert_large_uncased.yaml
+++ b/configs/sample/glue/wnli/kd/bert_base_uncased_from_bert_large_uncased.yaml
@@ -69,9 +69,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'optimizer_no_decay'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/at/resnet18_from_resnet34.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/at/resnet18_from_resnet34.yaml
@@ -83,9 +83,6 @@ train:
       output: ['layer3', 'layer4']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/cckd/resnet18_from_resnet50.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/cckd/resnet18_from_resnet50.yaml
@@ -104,9 +104,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/crd/resnet18_from_resnet50.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/crd/resnet18_from_resnet50.yaml
@@ -109,9 +109,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/cse_l2/resnet18_from_resnet34.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/cse_l2/resnet18_from_resnet34.yaml
@@ -83,9 +83,6 @@ train:
       output: ['avgpool']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/ghnd/custom_densenet169_from_densenet169.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/ghnd/custom_densenet169_from_densenet169.yaml
@@ -88,9 +88,6 @@ train:
       output: ['features.bottleneck', 'features.transition3', 'features.denseblock4']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/ghnd/custom_densenet201_from_densenet201.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/ghnd/custom_densenet201_from_densenet201.yaml
@@ -88,9 +88,6 @@ train:
       output: ['features.bottleneck', 'features.transition3', 'features.denseblock4']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/ghnd/custom_inception_v3_from_inception_v3.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/ghnd/custom_inception_v3_from_inception_v3.yaml
@@ -99,9 +99,6 @@ train:
       output: ['bottleneck', 'Mixed_5d', 'Mixed_6e', 'Mixed_7c']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/ghnd/custom_resnet152_from_resnet152.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/ghnd/custom_resnet152_from_resnet152.yaml
@@ -88,9 +88,6 @@ train:
       output: ['bottleneck', 'layer3', 'layer4']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/hnd/custom_densenet169_from_densenet169.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/hnd/custom_densenet169_from_densenet169.yaml
@@ -88,9 +88,6 @@ train:
       output: ['features.bottleneck']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/hnd/custom_densenet201_from_densenet201.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/hnd/custom_densenet201_from_densenet201.yaml
@@ -88,9 +88,6 @@ train:
       output: ['features.bottleneck']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/hnd/custom_inception_v3_from_inception_v3.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/hnd/custom_inception_v3_from_inception_v3.yaml
@@ -99,9 +99,6 @@ train:
       output: ['bottleneck']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/hnd/custom_resnet152_from_resnet152.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/hnd/custom_resnet152_from_resnet152.yaml
@@ -88,9 +88,6 @@ train:
       output: ['bottleneck']
     wrapper: 'DistributedDataParallel'
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/kd/alexnet_from_resnet152.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/kd/alexnet_from_resnet152.yaml
@@ -77,9 +77,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/kd/resnet18_from_resnet152.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/kd/resnet18_from_resnet152.yaml
@@ -77,9 +77,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/kr/resnet18_from_resnet34.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/kr/resnet18_from_resnet34.yaml
@@ -118,9 +118,6 @@ train:
     wrapper:
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/pkt/resnet18_from_resnet152.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/pkt/resnet18_from_resnet152.yaml
@@ -83,9 +83,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/rkd/resnet18_from_resnet34.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/rkd/resnet18_from_resnet34.yaml
@@ -83,9 +83,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'Adam'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/spkd/resnet18_from_resnet34.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/spkd/resnet18_from_resnet34.yaml
@@ -83,9 +83,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/tfkd/resnet18_from_resnet18.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/tfkd/resnet18_from_resnet18.yaml
@@ -77,9 +77,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/ilsvrc2012/single_stage/vid/resnet18_from_resnet50.yaml
+++ b/configs/sample/ilsvrc2012/single_stage/vid/resnet18_from_resnet50.yaml
@@ -119,9 +119,6 @@ train:
       output: ['student_model.layer1', 'student_model.layer2', 'student_model.layer3', 'student_model.layer4', 'regressor_dict.regressor1', 'regressor_dict.regressor2', 'regressor_dict.regressor3', 'regressor_dict.regressor4']
     wrapper:
     requires_grad: True
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/pascal_voc2012/ce/deeplabv3_resnet101.yaml
+++ b/configs/sample/pascal_voc2012/ce/deeplabv3_resnet101.yaml
@@ -93,9 +93,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/configs/sample/pascal_voc2012/ce/deeplabv3_resnet50.yaml
+++ b/configs/sample/pascal_voc2012/ce/deeplabv3_resnet50.yaml
@@ -93,9 +93,6 @@ train:
     wrapper: 'DistributedDataParallel'
     requires_grad: True
     frozen_modules: []
-  apex:
-    requires: False
-    opt_level: '01'
   optimizer:
     type: 'SGD'
     params:

--- a/torchdistill/core/training.py
+++ b/torchdistill/core/training.py
@@ -1,13 +1,11 @@
-import sys
-
 import torch
 from torch import distributed as dist
 from torch import nn
 from torch.optim.lr_scheduler import ReduceLROnPlateau, LambdaLR
 
 from torchdistill.common.constant import def_logger
-from torchdistill.common.module_util import check_if_wrapped, freeze_module_params, get_module, unfreeze_module_params, \
-    get_updatable_param_names
+from torchdistill.common.module_util import check_if_wrapped, freeze_module_params, get_module, \
+    unfreeze_module_params, get_updatable_param_names
 from torchdistill.core.forward_proc import get_forward_proc_func
 from torchdistill.core.util import set_hooks, wrap_model, clear_io_dict, extract_io_dict, update_io_dict
 from torchdistill.datasets.util import build_data_loaders
@@ -19,10 +17,6 @@ from torchdistill.models.util import redesign_model
 from torchdistill.optim.registry import get_optimizer, get_scheduler
 
 logger = def_logger.getChild(__name__)
-try:
-    from apex import amp
-except ImportError:
-    amp = None
 
 
 class TrainingBox(nn.Module):
@@ -136,21 +130,10 @@ class TrainingBox(nn.Module):
             self.lr_scheduler = None
             self.scheduling_step = None
 
-        # Set up accelerator/apex if necessary
-        self.apex = False
-        apex_config = train_config.get('apex', None)
+        # Set up accelerator if necessary
         if self.accelerator is not None:
             self.model, self.optimizer, self.train_data_loader, self.val_data_loader = \
                 self.accelerator.prepare(self.model, self.optimizer, self.train_data_loader, self.val_data_loader)
-        elif apex_config is not None and apex_config.get('requires', False):
-            if sys.version_info < (3, 0):
-                raise RuntimeError('Apex currently only supports Python 3. Aborting.')
-            if amp is None:
-                raise RuntimeError('Failed to import apex. Please install apex from https://www.github.com/nvidia/apex '
-                                   'to enable mixed-precision training.')
-            self.model, self.optimizer =\
-                amp.initialize(self.model, self.optimizer, opt_level=apex_config['opt_level'])
-            self.apex = True
 
     def __init__(self, model, dataset_dict, train_config, device, device_ids, distributed, lr_factor, accelerator=None):
         super().__init__()
@@ -174,7 +157,6 @@ class TrainingBox(nn.Module):
         self.max_grad_norm = None
         self.scheduling_step = 0
         self.stage_grad_count = 0
-        self.apex = None
         self.setup(train_config)
         self.num_epochs = train_config['num_epochs']
 
@@ -205,16 +187,12 @@ class TrainingBox(nn.Module):
 
         if self.accelerator is not None:
             self.accelerator.backward(loss)
-        elif self.apex:
-            with amp.scale_loss(loss, self.optimizer) as scaled_loss:
-                scaled_loss.backward()
         else:
             loss.backward()
 
         if self.stage_grad_count % self.grad_accum_step == 0:
             if self.max_grad_norm is not None:
-                target_params = amp.master_params(self.optimizer) if self.apex \
-                    else [p for group in self.optimizer.param_groups for p in group['params']]
+                target_params = [p for group in self.optimizer.param_groups for p in group['params']]
                 torch.nn.utils.clip_grad_norm_(target_params, self.max_grad_norm)
 
             self.optimizer.step()


### PR DESCRIPTION
This PR resolves the concern raised in Discussion #247 that PyTorch introduced `torch.cuda.amp` and deprecated `apex.amp`.